### PR TITLE
Update to Nutrient iOS dependency 26.0.0

### DIFF
--- a/dotnet-pdf-library-for-mobiles/dotnet-pdf-library-for-mobiles.csproj
+++ b/dotnet-pdf-library-for-mobiles/dotnet-pdf-library-for-mobiles.csproj
@@ -63,8 +63,8 @@
     <Choose>
         <When Condition="'$(TargetFramework)' == 'net8.0-ios'">
 					<ItemGroup>
-						<PackageReference Include="Nutrient.dotnet.iOS.Model" Version="14.11.0" />
-						<PackageReference Include="Nutrient.dotnet.iOS.UI" Version="14.11.0" />
+						<PackageReference Include="Nutrient.dotnet.iOS.Model" Version="26.0.0" />
+						<PackageReference Include="Nutrient.dotnet.iOS.UI" Version="26.0.0" />
 					</ItemGroup>
 				</When>
 		</Choose>


### PR DESCRIPTION
A maintenance task to keep the external `dotnet-for-mobiles` references up to date with whats going on in the monorepo. Since the `dotnet-for-ios` repo was already updated, the monorepo script will not be run to update this repo as well. Monorepo PR here: https://github.com/PSPDFKit/PSPDFKit/pull/48849